### PR TITLE
Fixes bugs caused by server move & security update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uni-Siegen</groupId>
   <artifactId>medienaesthetik</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.2-SNAPSHOT</version>
   <name>manager</name>
   <properties>
   	<java.version>1.8</java.version>
@@ -63,12 +63,12 @@
   <dependency>
   	<groupId>org.apache.tika</groupId>
   	<artifactId>tika-core</artifactId>
-  	<version>1.14</version>
+  	<version>1.19.1</version>
   </dependency>
   <dependency>
   	<groupId>org.apache.tika</groupId>
   	<artifactId>tika-parsers</artifactId>
-  	<version>1.14</version>
+  	<version>1.19.1</version>
   </dependency>
   <dependency>
     <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/medienaesthetik/coverPage/PDFMerger.java
+++ b/src/main/java/medienaesthetik/coverPage/PDFMerger.java
@@ -49,11 +49,11 @@ public class PDFMerger implements FolderChangeListener{
 			try {
 				File textFile = new File(UtilityFunctions.findFileByID(documentId));
 				File coverPage = new File(UtilityFunctions.findCoverPagebyID(documentId));
-				// Does the new Document already have a cover Page? (Every Cover Page has "medaes13" printed on it)
+				// Does the new Document already have a cover Page? (Every Cover Page has "medaes14" printed on it)
 				if(textFile.exists() && coverPage.exists()){
 					PDDocument PDDoc = PDDocument.load(textFile);
 					String textContent = new PDFTextStripper().getText(PDDoc);
-					if(!textContent.contains("medaes13")){
+					if(!textContent.contains("medaes14")){
 						logger.info("Dokument ohne Deckblatt gefunden: "+textFile);
 						// Add the found text document to the cover page
 						try {


### PR DESCRIPTION
Fixes bugs that have been caused by moving from MedAes 13 to 14 and adresses some other, small issues.

- Fixed a string and comment that look for "medaes13" in the PDF-merger, since the URL printed on the Cover pages will now contain "medaes14" instead.

- Updates Apache dependencies due to security concerns.